### PR TITLE
[ServerStatistics]

### DIFF
--- a/ServerStatisticsCollectionService/AppConfiguration.cs
+++ b/ServerStatisticsCollectionService/AppConfiguration.cs
@@ -1,0 +1,22 @@
+﻿using Microsoft.Extensions.Configuration;
+
+namespace ServerStatisticsCollectionService
+{
+    public static class AppConfiguration
+    {
+        public static string RabbitMQHostName { get; set; }
+        public static string RabbitMQUserName { get; set; }
+        public static string RabbitMQPassword { get; set; }
+        public static int SamplingIntervalSeconds { get; set; }
+        public static string ServerIdentifier { get; set; }
+
+        public static void Load(IConfiguration configuration)
+        {
+            RabbitMQHostName = configuration["RabbitMQ:HostName"];
+            RabbitMQUserName = configuration["RabbitMQ:UserName"];
+            RabbitMQPassword = configuration["RabbitMQ:Password"];
+            SamplingIntervalSeconds = Int32.Parse(configuration["ServerStatisticsConfig:SamplingIntervalSeconds"]);
+            ServerIdentifier = configuration["ServerStatisticsConfig:ServerIdentifier"];
+        }
+    }
+}

--- a/ServerStatisticsCollectionService/IMessageQueue.cs
+++ b/ServerStatisticsCollectionService/IMessageQueue.cs
@@ -1,0 +1,7 @@
+﻿namespace ServerStatisticsCollectionService
+{
+    public interface IMessageQueue
+    {
+        void Publish(string topic, ServerStatistics statistics);
+    }
+}

--- a/ServerStatisticsCollectionService/Program.cs
+++ b/ServerStatisticsCollectionService/Program.cs
@@ -1,9 +1,28 @@
-﻿namespace ServerStatisticsCollectionService
+﻿using Serilog;
+using Serilog.Core;
+using Serilog.Events;
+
+namespace ServerStatisticsCollectionService
 {
     class Program
     {
         static async Task Main(string[] args)
         {
+        }
+        public void LoggerConfiguration()
+        {
+            var currentDirectory = Directory.GetCurrentDirectory();
+
+            Log.Logger = new LoggerConfiguration()
+                        .WriteTo.File(Path.Combine(currentDirectory, "Information.log"),
+                         restrictedToMinimumLevel: LogEventLevel.Information,
+                         rollingInterval: RollingInterval.Day,
+                         rollOnFileSizeLimit: true)
+                        .WriteTo.File(Path.Combine(currentDirectory, "Error.log"),
+                         restrictedToMinimumLevel: LogEventLevel.Error,
+                         rollingInterval: RollingInterval.Day,
+                         rollOnFileSizeLimit: true)
+                         .CreateLogger();
         }
     }
 }

--- a/ServerStatisticsCollectionService/Resources.cs
+++ b/ServerStatisticsCollectionService/Resources.cs
@@ -1,0 +1,8 @@
+﻿namespace ServerStatisticsCollectionService
+{
+    enum Resources
+    {
+        Processor,
+        Memory
+    }
+}

--- a/ServerStatisticsCollectionService/ServerStatistics.cs
+++ b/ServerStatisticsCollectionService/ServerStatistics.cs
@@ -1,0 +1,10 @@
+﻿namespace ServerStatisticsCollectionService
+{
+    public class ServerStatistics
+    {
+        public double MemoryUsage { get; set; } // in MB
+        public double AvailableMemory { get; set; } // in MB
+        public double CpuUsage { get; set; }
+        public DateTime Timestamp { get; set; }
+    }
+}

--- a/ServerStatisticsCollectionService/ServerStatisticsCollectionService.csproj
+++ b/ServerStatisticsCollectionService/ServerStatisticsCollectionService.csproj
@@ -7,4 +7,12 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="7.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="7.0.0" />
+    <PackageReference Include="Serilog" Version="3.0.1" />
+    <PackageReference Include="Serilog.Sinks.File" Version="5.0.0" />
+    <PackageReference Include="System.Diagnostics.PerformanceCounter" Version="7.0.0" />
+  </ItemGroup>
+
 </Project>

--- a/ServerStatisticsCollectionService/ServerStatisticsCollector.cs
+++ b/ServerStatisticsCollectionService/ServerStatisticsCollector.cs
@@ -1,0 +1,69 @@
+﻿using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Hosting;
+using System.Diagnostics;
+
+namespace ServerStatisticsCollectionService
+{
+    public class ServerStatisticsCollector : IHostedService, IDisposable
+    {
+        private readonly IMessageQueue _messageQueue;
+
+        private int _samplingIntervalSeconds;
+        private string _serverIdentifier;
+        private Timer _timer;
+        private double _mb=1024.0*1024.0;
+
+        public void Dispose()
+        {
+            _timer?.Change(Timeout.Infinite, 0);
+            _timer?.Dispose();
+        }
+        public Task StartAsync(CancellationToken cancellationToken)
+        {
+            _samplingIntervalSeconds = AppConfiguration.SamplingIntervalSeconds;
+            _serverIdentifier = AppConfiguration.ServerIdentifier;
+
+            _timer = new Timer(CollectAndPublishStatistics, null, TimeSpan.Zero, TimeSpan.FromSeconds(_samplingIntervalSeconds)); ;
+
+            return Task.CompletedTask;
+        }
+        public Task StopAsync(CancellationToken cancellationToken)
+        {
+            _timer?.Change(Timeout.Infinite, 0);
+            return Task.CompletedTask;
+        }
+        private void CollectAndPublishStatistics(object state)
+        {
+            var statistics = new ServerStatistics
+            {
+                MemoryUsage = GetMemoryUsage(),
+                AvailableMemory = GetAvailableMemory(),
+                CpuUsage = GetCpuUsage(),
+                Timestamp = DateTime.UtcNow
+            };
+
+            _messageQueue.Publish($"{Topics.ServerStatistics.ToString()}.{_serverIdentifier}", statistics);
+        }
+        private double GetMemoryUsage()
+        {
+            using (var process = Process.GetCurrentProcess())
+            {
+                return process.PrivateMemorySize64 / _mb; // Convert bytes to MB
+            }
+        }
+        private double GetCpuUsage()
+        {
+            using (var pc = new PerformanceCounter(Resources.Processor.ToString(), "% Processor Time", "_Total"))
+            {
+                return pc.NextValue();
+            }
+        }
+        private double GetAvailableMemory()
+        {
+            using (var pc = new PerformanceCounter(Resources.Memory.ToString(), "Available MBytes"))
+            {
+                return pc.NextValue();
+            }
+        }
+    }
+}

--- a/ServerStatisticsCollectionService/Topics.cs
+++ b/ServerStatisticsCollectionService/Topics.cs
@@ -1,0 +1,4 @@
+﻿enum Topics
+{
+    ServerStatistics,
+}


### PR DESCRIPTION
This commit adds a new class, ServerStatistics, which is responsible for encapsulating server statistics, including memory usage, available memory, CPU usage, and a timestamp. This class will be used to store and represent the collected server statistics before they are published to a message queue.